### PR TITLE
fix(ci): fix release pipeline via runner's Chrome for e2e (stay on Stencil 2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '16'
           registry-url: 'https://registry.npmjs.org'
           scope: '@betha-plataforma'
 
       - name: Install
         run: yarn install --frozen-lockfile
+
+      - name: Use runner's pre-installed Chrome for e2e
+        run: echo "PUPPETEER_EXECUTABLE_PATH=${CHROME_BIN:-/usr/bin/google-chrome}" >> "$GITHUB_ENV"
 
       - name: Test
         run: yarn test
@@ -35,3 +38,5 @@ jobs:
 
       - name: Publish
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,15 +9,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
-          node-version: "12.17"
+          node-version: "16"
 
       - name: Install
         run: yarn install --frozen-lockfile
+
+      - name: Use runner's pre-installed Chrome for e2e
+        run: echo "PUPPETEER_EXECUTABLE_PATH=${CHROME_BIN:-/usr/bin/google-chrome}" >> "$GITHUB_ENV"
 
       - name: Test
         run: yarn test


### PR DESCRIPTION
## What

Fix the broken Release pipeline **without** upgrading Stencil — staying on Stencil 2 so the published `.d.ts` remain TypeScript 4 compatible.

## Why

The Release workflow failed at the **test step**: Puppeteer's bundled Chromium no longer installs/launches on modern CI runners. That is an **e2e Chrome provisioning** problem, independent of the Stencil version.

The earlier attempt bundled an unrelated toolchain modernization (Stencil 2 → 4, Jest, Puppeteer). Stencil 4 emits **TS 5** type declarations (`const` type params, `attr:${K}` key remapping) that **TS 4.0 / Angular 11 consumers cannot parse** — even with `skipLibCheck` — which breaks downstream apps like `app-documentos`. That made it a breaking change disguised as a minor.

## What changed

- **Toolchain reverted to Stencil 2** (`@stencil/core`, `@stencil/sass`, `jest`, `puppeteer`, `@types/jest`) → generated types stay TS4-compatible.
- **The actual fix kept:** `PUPPETEER_EXECUTABLE_PATH` points e2e at the runner's pre-installed Chrome.
- `NODE_AUTH_TOKEN` fallback on publish; CI pinned to **Node 16** (Stencil 2's supported runtime).
- Net diff vs `master` is **workflows only** — all source/generated files are identical to `master`.

## Verified locally (Node 16)

- `yarn build` green on Stencil 2.19.2-0; `dist/types` free of TS5 syntax.
- `app-documentos` `ng build` passes (exit 0) against this build — no app changes required.

## Note

The e2e step on the **Linux runner** is the one thing local (macOS) can't reproduce — this PR's `pull_request.yml` run is the real proof. If Puppeteer 9 can't drive the runner's modern Chrome over CDP, the fallback is a small Puppeteer bump within Stencil 2's supported range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)