### PR TITLE
#:PD-26485: Cópia de impressão só quando o processo de assinaturas conclui

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betha-plataforma/nopaper-componentes",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Coleção de Web Components NoPaper",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components/detalhes-assinatura/detalhes-assinatura.tsx
+++ b/src/components/detalhes-assinatura/detalhes-assinatura.tsx
@@ -311,7 +311,7 @@ export class DetalhesAssinatura implements DetalhesAssinaturaProps {
             downloadUrl: this.linkAssinador
                 ? this.getLinkDocumentoAssinador(documento.id)
                 : this.getDownloadUrlDocumento(documento.urlDownloadFront, documento.tipo === 'PDF'),
-            arquivoUrl: this.getDownloadUrlDocumento(this.getUrlArquivo(documento), documento.tipo === 'PDF'),
+            arquivoUrl: this.getDownloadUrlDocumento(documento.urlDownloadFront, documento.tipo === 'PDF'),
             arquivoAssinadoUrl: this.getUrlArquivoAssinado(documento)
         };
     }
@@ -322,20 +322,6 @@ export class DetalhesAssinatura implements DetalhesAssinaturaProps {
 
     private isDocumentoAssinado(documento): boolean {
         return this.getSituacaoDocumento(documento) === 'ASSINADO';
-    }
-
-    private isAlguemAssinou(documento): boolean {
-        return (documento.secoesAssinaturas || [])
-            .flatMap(secaoAssinatura => secaoAssinatura.assinantes || [])
-            .some(assinante => (assinante.situacaoAssinatura?.value || assinante.situacaoAssinatura) === 'ASSINADO');
-    }
-
-    private getUrlArquivo(documento): string {
-        if (isNill(documento.urlDownloadFront) || !this.isDocumentoPdf(documento)) {
-            return documento.urlDownloadFront;
-        }
-        const endpoint = this.isAlguemAssinou(documento) ? 'download-copia-impressao' : 'download-original';
-        return `${ this.getBaseUrlArquivo(documento) }/${ endpoint }`;
     }
 
     private getUrlArquivoAssinado(documento): string | undefined {

--- a/src/components/detalhes-assinatura/test/detalhes-assinatura.spec.tsx
+++ b/src/components/detalhes-assinatura/test/detalhes-assinatura.spec.tsx
@@ -331,7 +331,7 @@ describe('nopaper-detalhes-assinatura', () => {
     });
 
     it('PDF assinado: link do arquivo baixa a cópia de impressão e exibe o botão "Abrir assinado (PAdES)"', async () => {
-        // Arrange — backend manda copia-impressao para assinado+PDF; o componente troca para download-assinado
+        // Arrange — assinado+PDF: o urlDownloadFront já vem como copia-impressao; o link do arquivo usa essa URL
         const PAYLOAD_PDF_ASSINADO = JSON.parse(JSON.stringify(PAYLOAD));
         PAYLOAD_PDF_ASSINADO.content[0].tipo = 'PDF';
         PAYLOAD_PDF_ASSINADO.content[0].situacao = { value: 'ASSINADO' };
@@ -359,12 +359,14 @@ describe('nopaper-detalhes-assinatura', () => {
         expect(botaoAssinado.getAttribute('target')).toEqualText('_blank');
     });
 
-    it('PDF não assinado: link do arquivo baixa a cópia de impressão', async () => {
-        // Arrange — backend manda download-assinado enquanto não assinado; o componente troca para copia-impressao
-        const PAYLOAD_PDF_EM_ANDAMENTO = JSON.parse(JSON.stringify(PAYLOAD));
-        PAYLOAD_PDF_EM_ANDAMENTO.content[0].tipo = 'PDF';
-        PAYLOAD_PDF_EM_ANDAMENTO.content[0].situacao = { value: 'AGUARDANDO_ACEITE' };
-        setFetchMockData(PAYLOAD_PDF_EM_ANDAMENTO);
+    it('PDF parcialmente assinado (assinaturas pendentes): link segue o urlDownloadFront (download-assinado → original)', async () => {
+        // Arrange — PD-26485: documento com múltiplas assinaturas, uma realizada e as demais pendentes.
+        // Processo não concluído: o urlDownloadFront aponta para download-assinado (que serve o original);
+        // o componente não deve forçar a cópia de impressão só por já existir alguém que assinou.
+        const PAYLOAD_PDF_PARCIALMENTE_ASSINADO = JSON.parse(JSON.stringify(PAYLOAD));
+        PAYLOAD_PDF_PARCIALMENTE_ASSINADO.content[0].tipo = 'PDF';
+        PAYLOAD_PDF_PARCIALMENTE_ASSINADO.content[0].situacao = { value: 'PARCIALMENTE_ASSINADO' };
+        setFetchMockData(PAYLOAD_PDF_PARCIALMENTE_ASSINADO);
 
         await page.setContent('<nopaper-detalhes-assinatura></nopaper-detalhes-assinatura>');
         const detalhesAssinaturaElement: HTMLNopaperDetalhesAssinaturaElement = page.body.querySelector('nopaper-detalhes-assinatura');
@@ -374,14 +376,14 @@ describe('nopaper-detalhes-assinatura', () => {
         detalhesAssinaturaElement.protocolo = '67931ef5-da63-477f-8d92-fd671c3447c0';
         await page.waitForChanges();
 
-        // Assert — sem todas as assinaturas, não há botão de assinado, só a cópia de impressão
+        // Assert — link segue o urlDownloadFront (download-assinado) e não há botão de assinado
         expect(detalhesAssinaturaElement.shadowRoot.querySelector('.card a').getAttribute('href'))
-            .toEqualText('https://plataforma-assinador.test.betha.cloud/assinador/v1/api-front/documentos/0000/download-copia-impressao?access_token=00000000-1111-2222-3333-4444444444&disableDownload=true');
+            .toEqualText('https://plataforma-assinador.test.betha.cloud/assinador/v1/api-front/documentos/0000/download-assinado?access_token=00000000-1111-2222-3333-4444444444&disableDownload=true');
         expect(detalhesAssinaturaElement.shadowRoot.querySelector('.btn-abrir-assinado')).toBeNull();
     });
 
-    it('PDF sem nenhuma assinatura: link do arquivo baixa o original e não exibe o botão de assinado', async () => {
-        // Arrange — ninguém assinou ainda: a cópia de impressão não existe, baixa o original
+    it('PDF sem nenhuma assinatura: link segue o urlDownloadFront (download-assinado → original)', async () => {
+        // Arrange — ninguém assinou: o urlDownloadFront aponta para download-assinado, que serve o original
         const PAYLOAD_PDF_SEM_ASSINATURA = JSON.parse(JSON.stringify(PAYLOAD));
         PAYLOAD_PDF_SEM_ASSINATURA.content[0].tipo = 'PDF';
         PAYLOAD_PDF_SEM_ASSINATURA.content[0].situacao = { value: 'AGUARDANDO_ACEITE' };
@@ -402,9 +404,9 @@ describe('nopaper-detalhes-assinatura', () => {
         detalhesAssinaturaElement.protocolo = '67931ef5-da63-477f-8d92-fd671c3447c0';
         await page.waitForChanges();
 
-        // Assert — sem nenhuma assinatura a cópia ainda não existe: link cai no original e não há botão de assinado
+        // Assert — link segue o urlDownloadFront (download-assinado) e não há botão de assinado
         expect(detalhesAssinaturaElement.shadowRoot.querySelector('.card a').getAttribute('href'))
-            .toEqualText('https://plataforma-assinador.test.betha.cloud/assinador/v1/api-front/documentos/0000/download-original?access_token=00000000-1111-2222-3333-4444444444&disableDownload=true');
+            .toEqualText('https://plataforma-assinador.test.betha.cloud/assinador/v1/api-front/documentos/0000/download-assinado?access_token=00000000-1111-2222-3333-4444444444&disableDownload=true');
         expect(detalhesAssinaturaElement.shadowRoot.querySelector('.btn-abrir-assinado')).toBeNull();
     });
 


### PR DESCRIPTION
## Problema (PD-26485)

> Assinar um documento com múltiplas assinaturas e visualizá-lo tendo assinaturas pendentes. Ao abrir o documento disponibilizado no popover, está baixando a **cópia de impressão**, e não o documento original.

O link do arquivo no popover de detalhes da assinatura (`nopaper-detalhes-assinatura`) **reconstruía** o endpoint de download em `getUrlArquivo`, decidindo por `isAlguemAssinou` — verdadeiro assim que **um** assinante assina (`.some(... === 'ASSINADO')`). Logo, um documento com várias assinaturas e pendências já caía em `download-copia-impressao` antes de o processo concluir.

## Causa raiz

O componente **ignorava o `urlDownloadFront`** (que o Assinador já entrega pronto) e tomava a decisão por conta própria — lógica duplicada que divergia do backend.

O `urlDownloadFront` do Assinador **já embarca o comportamento correto**:

| Estado | `urlDownloadFront` | O endpoint serve |
|---|---|---|
| `ASSINADO` + PDF | `download-copia-impressao` | cópia de impressão |
| Incompleto (parcial/pendente) | `download-assinado` | **o original** (`copyArquivoToOS` cai em `copyArquivoOriginalToOS` quando `situacao != ASSINADO`) |
| `ASSINADO` + não-PDF | `download-assinado` | arquivo assinado |

## Correção

O link do arquivo passa a **consumir o `urlDownloadFront` direto** e a lógica duplicada (`getUrlArquivo` + `isAlguemAssinou`) foi removida. Backend como fonte única.

- `ASSINADO` + PDF → cópia de impressão (+ botão "Abrir assinado (PAdES)")
- Processo **não** concluído (parcial, pendente, sem assinatura) → documento original
- Sem mudança de backend

## Versão

`1.6.0` → `1.6.1` (patch). Evita republicar a 1.6.0 já publicada e quebrar o integrity no `yarn.lock` do `app-documentos` (que passa a apontar para `1.6.1`).

## Testes

`stencil test --spec` → **22/22 verdes**, incluindo o cenário do chamado:
- `PDF assinado: ... baixa a cópia de impressão e exibe o botão "Abrir assinado (PAdES)"`
- `PDF parcialmente assinado (assinaturas pendentes): link segue o urlDownloadFront (download-assinado → original)`
- `PDF sem nenhuma assinatura: link segue o urlDownloadFront (download-assinado → original)`

---
> Base: `master`. Validado localmente em `app-documentos` com a 1.6.1 (build local).